### PR TITLE
Upgrade symfony cli to 4.17.0

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:experimental
 FROM curlimages/curl as symfony-cli
 RUN curl --http2 --compressed --location \
-  https://github.com/symfony/cli/releases/download/v4.16.4/symfony_linux_amd64.gz | \
+  https://github.com/symfony/cli/releases/download/v4.17.0/symfony_linux_amd64.gz | \
   gunzip - > /tmp/symfony \
-  && echo "a09650c78ac55bab12acd8b124bb1dec79ef155a99bcfb3463d626edc99f1adf  /tmp/symfony" | sha256sum -cs \
+  && echo "01142b751526dff6f0a8a793a1782d798663daa7cedffcc6ddb107b863266bee  /tmp/symfony" | sha256sum -cs \
   && chmod +x /tmp/symfony
 
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -26,7 +26,6 @@ RUN apk add --no-cache --virtual .build-deps \
 RUN adduser -u 1001 -D php
 USER php
 COPY --from=symfony-cli /tmp/symfony /usr/local/bin/symfony
-RUN mkdir -p ~/.symfony
 COPY --from=composer:1.10.6 /usr/bin/composer /usr/local/bin/composer
 # buildkit bug: despite uid=1001 in mount type cache... created with uid 0
 RUN mkdir -p ~/.composer

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:experimental
 FROM curlimages/curl as symfony-cli
 RUN curl --http2 --compressed --location \
-  https://github.com/symfony/cli/releases/download/v4.16.3/symfony_linux_amd64.gz | \
+  https://github.com/symfony/cli/releases/download/v4.16.4/symfony_linux_amd64.gz | \
   gunzip - > /tmp/symfony \
-  && echo "faabf48df94d168732b2400a43fc57ec23535169f5662b402be6bf1f5311077b  /tmp/symfony" | sha256sum -cs \
+  && echo "a09650c78ac55bab12acd8b124bb1dec79ef155a99bcfb3463d626edc99f1adf  /tmp/symfony" | sha256sum -cs \
   && chmod +x /tmp/symfony
 
 


### PR DESCRIPTION
* Update Symfony CLI version to 4.16.3 (#9)

* Latest symfony CLI require ~/.symfony folder (#11)

* chore(php): upgrade symfony cli (#13)

4.16.4 should fix directory creation, so reverting #11

Co-authored-by: Sébastien HOUZÉ <sebastien.houze@french-hospitality.fr>