### PR TITLE
fix(bref): pass trusted ca certs into bref custom openssl

### DIFF
--- a/bref/entrypoint.sh
+++ b/bref/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-[ $(id -u) -eq 0 ] && update-ca-trust
+[ $(id -u) -eq 0 ] && update-ca-trust && cp /etc/ssl/certs/ca-bundle.trust.crt /opt/bref/ssl/cert.pem
 
 exec "$@"


### PR DESCRIPTION
This is because bref [bring his own openssl](https://github.com/brefphp/bref/blob/af366b59dcc62f6708ea806accba3923f85a32e9/runtime/base/base.Dockerfile#L112-L151).